### PR TITLE
add knex config SSL config option when DATABASE_URL is present

### DIFF
--- a/src/server/models/thinky.js
+++ b/src/server/models/thinky.js
@@ -37,7 +37,8 @@ if (process.env.DB_JSON || global.DB_JSON) {
     pool: {
       min: process.env.DB_MIN_POOL || 2,
       max: process.env.DB_MAX_POOL || 10
-    }
+    },
+    ssl: use_ssl
   }
 } else {
   config = {


### PR DESCRIPTION
The PG knex config ssl option is required when using Standard+ Heroku PGSQL addons.

See: https://devcenter.heroku.com/changelog-items/1363
Edit: also, see: http://cek.io/blog/2016/10/24/knex-configuration-heroku/