### PR TITLE
Update default opt-out message

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -211,7 +211,7 @@ export class AssignmentTexterContact extends React.Component {
       snackbarError,
       snackbarActionTitle,
       snackbarOnTouchTap,
-      optOutMessageText: "I'm opting you out of texts immediately. Have a great day.",
+      optOutMessageText: "While we do not have any control over the public voter registration list provided by local election officials, we will not text you again from Working Families.",
       responsePopoverOpen: false,
       messageText: this.getStartingMessageText(),
       optOutDialogOpen: false,


### PR DESCRIPTION
Updating default opt-out message to "While we do not have any control over the public voter registration list provided by local election officials, we will not text you again from Working Families."