### PR TITLE
apply paginated campaigns fix to revision running in production

### DIFF
--- a/src/containers/PaginatedUsersRetriever.jsx
+++ b/src/containers/PaginatedUsersRetriever.jsx
@@ -45,10 +45,10 @@ export class PaginatedUsersRetriever extends Component {
             return prev
           }
           const returnValue = Object.assign({}, prev)
-          returnValue.users.people = returnValue.users.people.concat(
-            fetchMoreResult.data.users.people
+          returnValue.people.users = returnValue.people.users.concat(
+            fetchMoreResult.data.people.users
           )
-          returnValue.users.pageInfo = fetchMoreResult.data.users.pageInfo
+          returnValue.people.pageInfo = fetchMoreResult.data.people.pageInfo
           return returnValue
         }
       })


### PR DESCRIPTION
We made a fix last night (#75) but it was applied to `main`, and then `main` was deployed to production.  However, `main` wasn't running in production. 

This pull request applies the fix to the branch running in production.

This is the revision on github:   `http://github.com/lperson/Spoke/commit/36f2f8e`

This shows that what’s running in staging (based on the commit hash reported by Heroku) is the same as the branch `staging20180902`  `https://github.com/WorkingFamilies/Spoke/compare/staging20180902...36f2f8ec`

@joemcl @deasterdaywfp @codygordon @bdatkins 

Therefore, this pull request will merge the fix into `staging20180902`, and after the merge, `staging20180902` should be deployed.

