### PR TITLE
add suspended texter status

### DIFF
--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -51,6 +51,8 @@ class Home extends React.Component {
         this.props.router.push(`/admin/${user.ownerOrganizations[0].id}`)
       } else if (user.texterOrganizations.length > 0) {
         this.props.router.push(`/app/${user.texterOrganizations[0].id}`)
+      } else if (user.suspendedOrganizations.length > 0) {
+        this.props.router.push(`/app/${user.suspendedOrganizations[0].id}`)
       } else {
         this.setState({ orgLessUser: true })
       }
@@ -134,6 +136,9 @@ const mapQueriesToProps = () => ({
           id
         }
         texterOrganizations:organizations(role:"TEXTER") {
+          id
+        }
+        suspendedOrganizations:organizations(role:"SUSPENDED") {
           id
         }
       }

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -1,4 +1,4 @@
-export const ROLE_HIERARCHY = ['TEXTER', 'SUPERVOLUNTEER', 'ADMIN', 'OWNER']
+export const ROLE_HIERARCHY = ['SUSPENDED', 'TEXTER', 'SUPERVOLUNTEER', 'ADMIN', 'OWNER']
 
 export const isRoleGreater = (role1, role2) => (ROLE_HIERARCHY.indexOf(role1) > ROLE_HIERARCHY.indexOf(role2))
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -190,12 +190,12 @@ export const resolvers = {
       return query
     },
     interactionSteps: async (campaign, _, { user }) => {
-      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
       return campaign.interactionSteps
         || cacheableData.campaign.dbInteractionSteps(campaign.id)
     },
     cannedResponses: async (campaign, { userId }, { user }) => {
-      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
       return await cacheableData.cannedResponse.query({
         userId: userId || '',
         campaignId: campaign.id
@@ -218,7 +218,7 @@ export const resolvers = {
       // This is the same as hasUnassignedContacts, but the access control
       // is different because for TEXTERs it's just for dynamic campaigns
       // but hasUnassignedContacts for admins is for the campaigns list
-      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
       if (!campaign.use_dynamic_assignment || campaign.is_archived) {
         return false
       }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1209,7 +1209,7 @@ const rootResolvers = {
       const assignment = await loaders.assignment.load(id)
       const campaign = await loaders.campaign.load(assignment.campaign_id)
       if (assignment.user_id == user.id) {
-        await accessRequired(user, campaign.organization_id, 'TEXTER', /* allowSuperadmin=*/ true)
+        await accessRequired(user, campaign.organization_id, 'SUSPENDED', /* allowSuperadmin=*/ true)
       } else {
         await accessRequired(
           user,
@@ -1237,7 +1237,7 @@ const rootResolvers = {
       authRequired(user)
       const contact = await loaders.campaignContact.load(id)
       const campaign = await loaders.campaign.load(contact.campaign_id)
-      await accessRequired(user, campaign.organization_id, 'TEXTER', /* allowSuperadmin=*/ true)
+      await accessRequired(user, campaign.organization_id, 'SUSPENDED', /* allowSuperadmin=*/ true)
       return contact
     },
     organizations: async (_, { id }, { user }) => {

--- a/src/server/models/cacheable_queries/user.js
+++ b/src/server/models/cacheable_queries/user.js
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader'
 import { r } from '../../models'
-import { isRoleGreater } from '../../../lib/permissions'
+import { ROLE_HIERARCHY, isRoleGreater } from '../../../lib/permissions'
 
 /*
 KEY: texterauth-${authId}
@@ -28,8 +28,6 @@ userOrgsWithRole(role, user.id) -> organization list
 
 const userRoleKey = (userId) => `${process.env.CACHE_PREFIX || ''}texterroles-${userId}`
 const userAuthKey = (authId) => `${process.env.CACHE_PREFIX || ''}texterauth-${authId}`
-
-export const accessHierarchy = ['TEXTER', 'SUPERVOLUNTEER', 'ADMIN', 'OWNER']
 
 const getHighestRolesPerOrg = (userOrgs) => {
   const highestRolesPerOrg = {}
@@ -113,8 +111,8 @@ const dbLoadUserAuth = async (field, val) => {
 
 const userOrgs = async (userId, role) => {
   const acceptableRoles = (role
-                           ? accessHierarchy.slice(accessHierarchy.indexOf(role))
-                           : [...accessHierarchy])
+                           ? ROLE_HIERARCHY.slice(ROLE_HIERARCHY.indexOf(role))
+                           : [...ROLE_HIERARCHY])
   const orgRoles = await loadUserRoles(userId)
   const matchedOrgs = Object.keys(orgRoles).filter(orgId => (
     acceptableRoles.indexOf(orgRoles[orgId].role) !== -1
@@ -125,8 +123,8 @@ const userOrgs = async (userId, role) => {
 const orgRoles = async (userId, orgId) => {
   const orgRolesDict = await loadUserRoles(userId)
   if (orgId in orgRolesDict) {
-    return accessHierarchy.slice(
-      0, 1 + accessHierarchy.indexOf(orgRolesDict[orgId].role))
+    return ROLE_HIERARCHY.slice(
+      0, 1 + ROLE_HIERARCHY.indexOf(orgRolesDict[orgId].role))
   }
   return []
 }
@@ -154,14 +152,14 @@ const userOrgHighestRole = async (userId, orgId) => {
     if (roles.length) {
       highestRole = roles
         .map(ri => ri.role)
-        .sort((a, b) => accessHierarchy.indexOf(b) - accessHierarchy.indexOf(a))[0]
+        .sort((a, b) => ROLE_HIERARCHY.indexOf(b) - ROLE_HIERARCHY.indexOf(a))[0]
     }
   }
   return highestRole
 }
 
 const userHasRole = async (user, orgId, role) => {
-  const acceptableRoles = accessHierarchy.slice(accessHierarchy.indexOf(role))
+  const acceptableRoles = ROLE_HIERARCHY.slice(ROLE_HIERARCHY.indexOf(role))
   let highestRole = ''
   if (user.orgRoleCache) {
     highestRole = await user.orgRoleCache.load(`${user.id}:${orgId}`)

--- a/src/server/models/user-organization.js
+++ b/src/server/models/user-organization.js
@@ -9,7 +9,7 @@ const UserOrganization = thinky.createModel('user_organization', type.object().s
   id: type.string(),
   user_id: requiredString(),
   organization_id: requiredString(),
-  role: requiredString().enum('OWNER', 'ADMIN', 'SUPERVOLUNTEER', 'TEXTER')
+  role: requiredString().enum('OWNER', 'ADMIN', 'SUPERVOLUNTEER', 'TEXTER', 'SUSPENDED')
 }).allowExtra(false), { noAutoCreation: true,
                         dependencies: [User, Organization]
                       })


### PR DESCRIPTION
Context: a step toward building #83.

With this change, an administrator can go into the people page and change a texter’s role to `SUSPENDED`.

The only difference is that when you’re in message review, and you go to reassign conversations, suspended texters will show up as `Larry Person SUSPENDED`.

Otherwise users with the role `SUSPENDED` function exactly like users with the role `TEXTER`.