### PR TITLE
be extremely permissive about matching canned responses and interactions headings

### DIFF
--- a/src/server/api/lib/import-script..js
+++ b/src/server/api/lib/import-script..js
@@ -101,7 +101,7 @@ const getSections = compose(
   filter(hasParagraph)
 )
 
-const getSectionParagraphs = (sections, heading) => (sections.find((section) => section.text && section.text.toLowerCase() === heading.toLowerCase()) || {}).paragraphs
+const getSectionParagraphs = (sections, heading) => (sections.find((section) => section.text && section.text.toLowerCase().match(new RegExp(heading.toLowerCase()))) || {}).paragraphs
 
 const getInteractions = (sections) => getSectionParagraphs(sections, 'Interactions')
 const getCannedResponses = (sections) => getSectionParagraphs(sections, 'Canned Responses')


### PR DESCRIPTION
Context: script import.

Basically, if something with style `heading_2` contains the text `canned responses` or `interactions` it will match, not matter what spaces or garbage characters may precede or follow.