### PR TITLE
use auth0 to initiate password reset when not using local passport strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ To simulate receiving a reply from a contact you can use the Send Replies utilit
 
 **Twilio**
 
-Twilio provides test credentials that will not charge your account as described in their [documentation](https://www.twilio.com/docs/iam/test-credentials). You may use either your test credentials or your live keys by following the instructions [here](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO_INTEGRATE_TWILIO.md).
+Twilio provides [test credentials](https://www.twilio.com/docs/iam/test-credentials) that will not charge your account as described in their documentation. To setup Twilio follow our [Twilio setup guide](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO_INTEGRATE_TWILIO.md).
 
 
 ## Getting started with Docker
+
+Docker is optional, but can help with a consistent development environment using postgres.
 
 1. `cp .env.example .env` and see step 6 above for some possible tweaks
 2. Build and run Spoke with `docker-compose up --build`

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Please let us know if you deployed by filling out this form [here](https://act.m
     - Then use the generated key to visit an invite link, e.g.: http://localhost:3000/invite/abc. This should redirect you to the login screen. Use the "Sign Up" option to create your account.
 
 10. You should then be prompted to create an organization. Create it.
-
-If you want to create an invite via the home page "Login and get started" link, make sure your `SUPPRESS_SELF_INVITE` variable is not set.
+11. See the [Admin and Texter demos](https://opensource.moveon.org/spoke-p2p#block-yui_3_17_2_25_1509554076500_36334) to learn about how Spoke works.
 
 ### SMS
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Please let us know if you deployed by filling out this form [here](https://act.m
 ## Getting started
 
 1. Install either sqlite (or another [knex](http://knexjs.org/#Installation-client)-supported database)
-2. Install the Node version listed in `.nvmrc`. [NVM](https://github.com/creationix/nvm) is one way to do this:
+2. Install the Node version listed in `.nvmrc`. [NVM](https://github.com/creationix/nvm) is one way to do this (from the spoke directory):
     ```
     nvm install
     nvm use
     ```
-3. `yarn install`
+3. `yarn install` (If yarn is not yet installed, run `npm install -g yarn` first)
 4. `cp .env.example .env`
 5. If you want to use Postgres:
     - In `.env` set `DB_TYPE=pg`. (Otherwise, you will use sqlite.)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Spoke was created by Saikat Chakrabarti and Sheena Pakanati, and is now maintain
 
 The latest version is [2.0.0](https://github.com/MoveOnOrg/Spoke/tree/v2.0) (see [release notes](https://github.com/MoveOnOrg/Spoke/blob/main/docs/RELEASE_NOTES.md#v20)) which we recommend for production use, while our `main` branch is where features still in development and testing will be available.
 
-## Note
-
-This is generated from [react-apollo-starter-kit](https://github.com/saikat/react-apollo-starter-kit).  Look at that project's README for info on some of the libraries used.
-
 ## Deploy to Heroku
 
 <a href="https://heroku.com/deploy?template=https://github.com/MoveOnOrg/Spoke/tree/v2.0">

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Please let us know if you deployed by filling out this form [here](https://act.m
 
 10. You should then be prompted to create an organization. Create it.
 11. See the [Admin and Texter demos](https://opensource.moveon.org/spoke-p2p#block-yui_3_17_2_25_1509554076500_36334) to learn about how Spoke works.
+12. See [Getting Started with Development](#more-documentation) below.
 
 ### SMS
 

--- a/README.md
+++ b/README.md
@@ -76,36 +76,13 @@ Docker is optional, but can help with a consistent development environment using
 5. You should then be prompted to create an organization. Create it.
 6. When done testing, clean up resources with `docker-compose down`, or `docker-compose down -v` to **_completely destroy_** your Postgres database & Redis datastore volumes.
 
-## Running Tests
-
-See https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-run_tests.md
-
-## Big Thanks
-Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https://saucelabs.com).
-
-## Helpful Dev Tips
-* Run `sqlite3 mydb.sqlite` to connect to a SQL shell for the dev database
-* [Set up an ESLint plugin in your code editor so that you catch coding errors and follow code style guidelines more easily!](https://medium.com/planet-arkency/catch-mistakes-before-you-run-you-javascript-code-6e524c36f0c8#.oboqsse48)
-* [Install the redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) in Chrome to get advanced Redux debugging features.
-* Right now there is a bug in Apollo (https://github.com/apollostack/react-apollo/issues/57) that means in one particular case, errors get swallowed.  If you end up with an app that is silently breaking, console.log(this.props.data) and check the errors property.
-
-## Deploying Minimally
-
-There are several ways to deploy documented below. This is the 'most minimal' approach:
-
-1. Run `OUTPUT_DIR=./build yarn run prod-build-server`
-   This will generate something you can deploy to production in ./build and run nodejs server/server/index.js
-2. Run `yarn run prod-build-client`
-3. Make a copy of `deploy/spoke-pm2.config.js.template`, e.g. `spoke-pm2.config.js`, add missing environment variables, and run it with [pm2](https://www.npmjs.com/package/pm2), e.g. `pm2 start spoke-pm2.config.js --env production`
-4. [Install PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
-5. Start PostgreSQL (e.g. `sudo /etc/init.d/postgresql start`), connect (e.g. `sudo -u postgres psql`), create a user and database (e.g. `create user spoke password 'spoke'; create database spoke owner spoke;`), disconnect (e.g. `\q`) and add credentials to `DB_` variables in spoke-pm2.config.js
 
 ## More Documentation
 
 * Getting Started with Development:
   * Welcome! Start with [CONTRIBUTING.md](./CONTRIBUTING.md) for community participation and engagement details.
-  * [Development Guidelines](https://github.com/MoveOnOrg/Spoke/blob/main/docs/EXPLANATION-development-guidelines.md)
-
+  * [Development Guidelines and Tips](https://github.com/MoveOnOrg/Spoke/blob/main/docs/EXPLANATION-development-guidelines.md)
+  * [Running Tests](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-run_tests.md)
 * More Development documentation
   * [A request example](https://github.com/MoveOnOrg/Spoke/blob/main/docs/EXPLANATION-request-example.md) pointing to different code points that all connect to it.
   * [GraphQL Debugging](https://github.com/MoveOnOrg/Spoke/blob/main/docs/graphql-debug.md)
@@ -129,6 +106,20 @@ There are several ways to deploy documented below. This is the 'most minimal' ap
   * Description of the different [Roles and Their Permissions](https://github.com/MoveOnOrg/Spoke/blob/main/docs/ROLES_DESCRIPTION.md)
   * Some DB queries for [Texter Activity](https://github.com/MoveOnOrg/Spoke/blob/main/docs/TEXTER_ACTIVITY_QUERIES.md)
 
+
+## Deploying Minimally
+
+There are several ways to deploy documented below. This is the 'most minimal' approach:
+
+1. Run `OUTPUT_DIR=./build yarn run prod-build-server`
+   This will generate something you can deploy to production in ./build and run nodejs server/server/index.js
+2. Run `yarn run prod-build-client`
+3. Make a copy of `deploy/spoke-pm2.config.js.template`, e.g. `spoke-pm2.config.js`, add missing environment variables, and run it with [pm2](https://www.npmjs.com/package/pm2), e.g. `pm2 start spoke-pm2.config.js --env production`
+4. [Install PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
+5. Start PostgreSQL (e.g. `sudo /etc/init.d/postgresql start`), connect (e.g. `sudo -u postgres psql`), create a user and database (e.g. `create user spoke password 'spoke'; create database spoke owner spoke;`), disconnect (e.g. `\q`) and add credentials to `DB_` variables in spoke-pm2.config.js
+
+## Big Thanks
+Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https://saucelabs.com).
 
 # License
 Spoke is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please let us know if you deployed by filling out this form [here](https://act.m
     - Set `DB_PORT=5432`, which is the default port for Postgres.
     - Create the spokedev database:  `psql -c "create database spokedev;"`
 6. Some other settings to tweak in dev -- make sure you are NOT editing .env.example -- edit `.env`:
-   * For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
+   * For development, you should probably set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
    * For production, you'll want to use Auth0 for login and set PASSPORT_STRATEGY=auth0 -- see [Auth0 for authentication](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-configure-auth0.md) for setup instructions
 
 7. Run `yarn dev` to start the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ Please let us know if you deployed by filling out this form [here](https://act.m
     - In `.env` set `DB_TYPE=pg`. (Otherwise, you will use sqlite.)
     - Set `DB_PORT=5432`, which is the default port for Postgres.
     - Create the spokedev database:  `psql -c "create database spokedev;"`
+6. Some other settings to tweak in dev:
+   * For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
+   * For production, you'll want to use Auth0 for login and set PASSPORT_STRATEGY=auth0 -- see [Auth0 for authentication](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-configure-auth0.md) for setup instructions
 
- Run `yarn dev` to restart the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)
-6. Go to `http://localhost:3000` to load the app.
-7. As long as you leave `SUPPRESS_SELF_INVITE=` blank and unset in your `.env` you should be able to invite yourself from the homepage.
+7. Run `yarn dev` to start the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)
+8. Go to `http://localhost:3000` to load the app and create the database (Note: the terminal will say it's running on port 8090 -- don't believe it :-) -- it's running a proxy on port 3000 which also includes static asset serving, etc.
+9. As long as you leave `SUPPRESS_SELF_INVITE=` blank and unset in your `.env` you should be able to invite yourself from the homepage.
     - If you DO set that variable, then spoke will be invite-only and you'll need to generate an invite. Run:
       ```
       echo "INSERT INTO invite (hash,is_valid) VALUES ('abc', 1);" |sqlite3 mydb.sqlite
@@ -47,17 +50,27 @@ Please let us know if you deployed by filling out this form [here](https://act.m
       ```
     - Then use the generated key to visit an invite link, e.g.: http://localhost:3000/invite/abc. This should redirect you to the login screen. Use the "Sign Up" option to create your account.
 
-8. You should then be prompted to create an organization. Create it.
+10. You should then be prompted to create an organization. Create it.
 
 If you want to create an invite via the home page "Login and get started" link, make sure your `SUPPRESS_SELF_INVITE` variable is not set.
 
+### SMS
+
+For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
+
+To simulate receiving a reply from a contact you can use the Send Replies utility: `http://localhost:3000/admin/1/campaigns/1/send-replies`, updating the app and campaign IDs as necessary.  You can also include "autorespond" in the script message text, and an automatic reply will be generated (just for `fakeservice`!)
+
+**Twilio**
+
+Twilio provides test credentials that will not charge your account as described in their [documentation](https://www.twilio.com/docs/iam/test-credentials). You may use either your test credentials or your live keys by following the instructions [here](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO_INTEGRATE_TWILIO.md).
+
+
 ## Getting started with Docker
 
-1. `cp .env.example .env`
+1. `cp .env.example .env` and see step 6 above for some possible tweaks
 2. Build and run Spoke with `docker-compose up --build`
     - You can stop docker compose at any time with `CTRL+C`, and data will persist next time you run `docker-compose up`.
 3. Go to [localhost:3000](http://localhost:3000) to load the app.
-4. Follow Step 13 above.
     - But if you need to generate an invite, run:
       ```bash
       docker-compose exec postgres psql -U spoke -d spokedev -c "INSERT INTO invite (hash,is_valid) VALUES ('<your-hash>', true);"
@@ -78,16 +91,6 @@ Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https
 * [Set up an ESLint plugin in your code editor so that you catch coding errors and follow code style guidelines more easily!](https://medium.com/planet-arkency/catch-mistakes-before-you-run-you-javascript-code-6e524c36f0c8#.oboqsse48)
 * [Install the redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) in Chrome to get advanced Redux debugging features.
 * Right now there is a bug in Apollo (https://github.com/apollostack/react-apollo/issues/57) that means in one particular case, errors get swallowed.  If you end up with an app that is silently breaking, console.log(this.props.data) and check the errors property.
-
-### SMS
-
-For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
-
-To simulate receiving a reply from a contact you can use the Send Replies utility: `http://localhost:3000/admin/1/campaigns/1/send-replies`, updating the app and campaign IDs as necessary.
-
-**Twilio**
-
-Twilio provides test credentials that will not charge your account as described in their [documentation](https://www.twilio.com/docs/iam/test-credentials). You may use either your test credentials or your live keys by following the instructions [here](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO_INTEGRATE_TWILIO.md).
 
 ## Deploying Minimally
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please let us know if you deployed by filling out this form [here](https://act.m
     - In `.env` set `DB_TYPE=pg`. (Otherwise, you will use sqlite.)
     - Set `DB_PORT=5432`, which is the default port for Postgres.
     - Create the spokedev database:  `psql -c "create database spokedev;"`
-6. Some other settings to tweak in dev:
+6. Some other settings to tweak in dev -- make sure you are NOT editing .env.example -- edit `.env`:
    * For development, you can set `DEFAULT_SERVICE=fakeservice` to skip using an SMS provider (Twilio or Nexmo) and insert the message directly into the database.
    * For production, you'll want to use Auth0 for login and set PASSPORT_STRATEGY=auth0 -- see [Auth0 for authentication](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-configure-auth0.md) for setup instructions
 

--- a/docs/EXPLANATION-development-guidelines.md
+++ b/docs/EXPLANATION-development-guidelines.md
@@ -113,6 +113,8 @@ Production instances can disable automatic migrations on startup with environmen
 
 ## Apollo/GraphQL structure and gotchas
 
+Spoke was originally generated from [react-apollo-starter-kit](https://github.com/saikat/react-apollo-starter-kit).  You can look at that project's README for info on some of the libraries used.
+
 See [EXPLANATION-request-example.md](./EXPLANATION-request-example.md) for a great run-down all the
 way through the call stack on the client and server.
 

--- a/docs/EXPLANATION-development-guidelines.md
+++ b/docs/EXPLANATION-development-guidelines.md
@@ -1,6 +1,6 @@
-# Development Guidelines
+# Development Guidelines and Tips
 
-This document describes current gotchas in our code base an explains the context
+This document describes tips and current gotchas in our code base and explains the context
 for parts that are evolving in a certain direction (or we *want* to evolve in a certain direction).
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) and the [README](../README.md) for setup
@@ -17,6 +17,12 @@ Generally, label by filename what kind of documentation it is in all-caps, one o
 * Explanation
 * How-to guide
 * Reference
+
+## Helpful Dev Tips
+* Run `sqlite3 mydb.sqlite` to connect to a SQL shell for the dev database
+* [Set up an ESLint plugin in your code editor so that you catch coding errors and follow code style guidelines more easily!](https://medium.com/planet-arkency/catch-mistakes-before-you-run-you-javascript-code-6e524c36f0c8#.oboqsse48)
+* [Install the redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) in Chrome to get advanced Redux debugging features.
+* Right now there is a bug in Apollo (https://github.com/apollostack/react-apollo/issues/57) that means in one particular case, errors get swallowed.  If you end up with an app that is silently breaking, console.log(this.props.data) and check the errors property.
 
 ## Dependency Management
 

--- a/docs/HOWTO-configure-auth0.md
+++ b/docs/HOWTO-configure-auth0.md
@@ -15,21 +15,20 @@ Spoke for Auth0.
 variables.
 2. Create an [Auth0](https://auth0.com) account. In your Auth0 account, go to [Applications](https://manage.auth0.com/#/applications/), click on `Default App` and then grab your Client ID, Client Secret, and your Auth0 domain (should look like xxx.auth0.com). Add those inside your `.env` file (AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN respectively).
 3. Run `yarn dev` to create and populate the tables.
-4. In your Auth0 app settings, set the following (Note: for development use `http://localhost:3000` instead of `https://yourspokedomain.com`):
-    + **Allowed Callback URLs** - `https://yourspokedomain.com/login-callback`
-    + **Allowed Web Origins** - `https://yourspokedomain.com`
-    + **Allowed Logout URLs** - `https://yourspokedomain.com/logout-callback`
-    + **Allowed Origins (CORS)** - `https://*.yourspokedomain.com`
-        - _Note: for development this will be `http://localhost:3000` without the `*.`_
-    + If you get an error when logging in later about "OIDC", go to Advanced Settings section, then OAuth, and turn off 'OIDC Conformant'.
-5. Add a new [rule](https://manage.auth0.com/#/rules/create) in Auth0:
+4. In your Auth0 app settings, set the following (Note: for development use `http://localhost:3000` instead of `https://yourspoke.example.com`):
+    + **Allowed Callback URLs** - `https://yourspoke.example.com/login-callback`
+    + **Allowed Web Origins** - `https://yourspoke.example.com`
+    + **Allowed Logout URLs** - `https://yourspoke.example.com/logout-callback`
+    + **Allowed Origins (CORS)** - `https://yourspoke.example.com`
+5. In Advanced Settings, under the OAuth section, turn off 'OIDC Conformant'.
+6. Add a [new empty rule](https://manage.auth0.com/#/rules/create) in Auth0:
 ```javascript
 function (user, context, callback) {
 context.idToken["https://spoke/user_metadata"] = user.user_metadata;
 callback(null, user, context);
 }
 ```
-6. Update the Auth0 [Universal Landing page](https://manage.auth0.com/#/login_page), click on the `Customize Login Page` toggle, and copy and paste following code in the drop down into the `Default Templates` space:
+7. Update the Auth0 [Universal Landing page](https://manage.auth0.com/#/login_page), click on the `Customize Login Page` toggle, and copy and paste following code in the drop down into the `Default Templates` space:
 
     <details>
     <summary>Code to paste into Auth0</summary>

--- a/docs/HOWTO-configure-auth0.md
+++ b/docs/HOWTO-configure-auth0.md
@@ -15,7 +15,13 @@ Spoke for Auth0.
 variables.
 2. Create an [Auth0](https://auth0.com) account. In your Auth0 account, go to [Applications](https://manage.auth0.com/#/applications/), click on `Default App` and then grab your Client ID, Client Secret, and your Auth0 domain (should look like xxx.auth0.com). Add those inside your `.env` file (AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN respectively).
 3. Run `yarn dev` to create and populate the tables.
-4. In your Auth0 app settings, add `http://localhost:3000/login-callback` , `http://localhost:3000` and `http://localhost:3000/logout-callback` to "Allowed Callback URLs", "Allowed Web Origins" and  "Allowed Logout URLs" respectively. (If you get an error when logging in later about "OIDC", go to Advanced Settings section, and then OAuth, and turn off 'OIDC Conformant')
+4. In your Auth0 app settings, set the following (Note: for development use `http://localhost:3000` instead of `https://yourspokedomain.com`):
+    + **Allowed Callback URLs** - `https://yourspokedomain.com/login-callback`
+    + **Allowed Web Origins** - `https://yourspokedomain.com`
+    + **Allowed Logout URLs** - `https://yourspokedomain.com/logout-callback`
+    + **Allowed Origins (CORS)** - `https://*.yourspokedomain.com`
+        - _Note: for development this will be `http://localhost:3000` without the `*.`_
+    + If you get an error when logging in later about "OIDC", go to Advanced Settings section, then OAuth, and turn off 'OIDC Conformant'.
 5. Add a new [rule](https://manage.auth0.com/#/rules/create) in Auth0:
 ```javascript
 function (user, context, callback) {

--- a/docs/HOWTO-configure-auth0.md
+++ b/docs/HOWTO-configure-auth0.md
@@ -9,7 +9,7 @@ in the database and resets, etc are administered all within Spoke.  While good f
 believe Auth0 still provides better security for production environments.  Below are the steps to configure
 Spoke for Auth0.
 
-## For Development
+## Configuration Steps
 
 1. First configure the environment variable `PASSPORT_STRATEGY=auth0` in `.env` or wherever to configure Spoke environment
 variables.

--- a/docs/HOWTO_HEROKU_DEPLOY.md
+++ b/docs/HOWTO_HEROKU_DEPLOY.md
@@ -8,39 +8,8 @@
 - There is a variable named `SUPPRESS_SELF_INVITE` in your configuration variables in Heroku. When this is set to nothing, anyone can visit your app and create an organization. When it is set to `true`, this changes login/signup behavior - when a person signs up and visits your app, they will not create an organization. On first deployment, it should be set to nothing to ensure that you have the ability to create an organization and view the full functionality of the application.
 
 ## Instructions for Auth0 configuration variable setup
-- Create an Auth0 account - click [here to visit Auth0's website to signup](https://auth0.com/signup)
-- After logging in to account, click on `Clients`
-- Click on `+Create Client`
-- Create a name and click on click on `Single Page App` - click create
-- If it asks for `What technology are you using?` - click React
-- Click on `Settings` in the tabs
-- You should see 3 variables at the top you need for your Heroku app.
-  - `Domain name` will be the value to put into the value for `AUTH0_DOMAIN` in Heroku
-  - `Client ID` will be the value to put into the value for `AUTH0_CLIENT_ID` in Heroku
-  - `Client Secret` will be the value to put into the value for `AUTH0_CLIENT_SECRET` in Heroku
-
-- Scroll to `Allowed Callback URLs` section and update it with your HEROKU_APP_URL:
-  - `https://<YOUR_HEROKU_APP_URL>/login-callback, http://<YOUR_HEROKU_APP_URL>/login-callback`
-
-- Scroll to `Allowed Logout URLs` section and update it with (your HEROKU_APP_URL):
-  - `https://<YOUR_HEROKU_APP_URL>/logout-callback, http://<YOUR_HEROKU_APP_URL>/logout-callback`
-
-- Scroll to `Allowed Origin (CORS)` add:
-  - `http://*.<YOUR_HEROKU_APP_URL>.com`, ` https://*.<YOUR_HEROKU_APP_URL>.com`
-- Scroll to `Allowed Web Origins` add:
-  - `http://<YOUR_HEROKU_APP_URL>.com`, ` https://<YOUR_HEROKU_APP_URL>.com`
-- Scroll to bottom and click on `Advanced Settings`
-  - Click on `OAuth` - make sure `OIDC Conformant` is turned off
-- Then create a rule in Auth0:
-  - Click [here](https://manage.auth0.com/#/rules/create) to navigate to rule creation tab when logged into Auth0
-  - Note: name of rule can be anything
-  - Paste the following code in the box where it says `function`:
-    ```javascript
-    function (user, context, callback) {
-      context.idToken["https://spoke/user_metadata"] = user.user_metadata;
-      callback(null, user, context);
-    }
-  - Now, it should only say the pasted code in the box. Click save.
+- Follow the instructions at [Auth0 for authentication](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-configure-auth0.md)
+  - Where the instructions mention `yourspoke.example.com`, replace it with `<YOUR SPOKE APP>.herokuapp.com` (or in production, possibly the domain you aliased to it in your DNS config)
 
 
 ## Notes about Twilio configuration variable setup

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -210,6 +210,7 @@ const rootSchema = gql`
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     resetUserPassword(organizationId: String!, userId: Int!): String!
     changeUserPassword(userId: Int!, formData: UserPasswordChange): User
+    initiatePasswordReset(organizationId: String!, userId: String!): Boolean
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization

--- a/src/components/PeopleList/index.jsx
+++ b/src/components/PeopleList/index.jsx
@@ -12,6 +12,7 @@ import { dataTest } from '../../lib/attributes'
 
 import PeopleIcon from 'material-ui/svg-icons/social/people'
 import Empty from '../../components/Empty'
+import InitiatePasswordResetDialog from '../../containers/InitiatePasswordResetDialog'
 
 const prepareDataTableData = (users) => users.map(user => ({
   texterId: user.id,
@@ -168,7 +169,7 @@ export class PeopleList extends Component {
         || nextLocation.query.sortBy !== currentLocation.query.sortBy
         || nextLocation.query.role !== currentLocation.query.role)
       && !nextProps.users.loading
-      ) {
+    ) {
       window.location.reload()
     }
   }
@@ -235,11 +236,18 @@ export class PeopleList extends Component {
   renderChangePasswordButton = (columnKey, row) => {
     const { texterId } = row
     const { currentUser } = this.props
-    return (
+    return window.PASSPORT_STRATEGY === 'local' ? (
       <FlatButton
         label='Reset Password'
         disabled={currentUser.id === texterId}
         onTouchTap={() => { this.resetPassword(texterId) }}
+      />
+    ) : (
+      <InitiatePasswordResetDialog
+        currentUser={currentUser.id}
+        userId={texterId}
+        organizationId={this.props.organizationId}
+        disabled={currentUser.id === texterId}
       />
     )
   }

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -20,6 +20,7 @@ import gql from 'graphql-tag'
 import { dataTest } from '../lib/attributes'
 import LoadingIndicator from '../components/LoadingIndicator'
 import PaginatedUsersRetriever from './PaginatedUsersRetriever'
+import InitiatePasswordResetDialog from './InitiatePasswordResetDialog';
 
 class AdminPersonList extends React.Component {
 
@@ -205,11 +206,20 @@ class AdminPersonList extends React.Component {
                   label='Edit'
                   onTouchTap={() => { this.editUser(person.id) }}
                 />
-                <FlatButton
-                  label='Reset Password'
-                  disabled={currentUser.id === person.id}
-                  onTouchTap={() => { this.resetPassword(person.id) }}
-                />
+                {window.PASSPORT_STRATEGY === 'local' ? (
+                  <FlatButton
+                    label='Reset Password'
+                    disabled={currentUser.id === person.id}
+                    onTouchTap={() => { this.resetPassword(person.id) }}
+                  />
+                ) : (
+                  <InitiatePasswordResetDialog
+                    currentUser={currentUser.id}
+                    userId={person.id}
+                    organizationId={this.props.organizationData.organization.id}
+                    disabled={currentUser.id === person.id}
+                  />
+                )}
               </TableRowColumn>
             </TableRow>
           ))}

--- a/src/containers/InitiatePasswordResetDialog.jsx
+++ b/src/containers/InitiatePasswordResetDialog.jsx
@@ -48,10 +48,14 @@ class InitiatePasswordResetDialog extends React.Component {
   }
 
   editingSelf = () => {
-    return this.props.currentUser.id === this.userId
+    return this.props.currentUser.id === this.props.userId
   }
 
   openDialog = () => {
+    if (this.props.disabled) {
+      return
+    }
+
     this.setState({ open: true })
   }
 
@@ -66,24 +70,24 @@ class InitiatePasswordResetDialog extends React.Component {
     if (this.editingSelf()) {
       if (this.state.alreadyInitiated) {
         return 'Check your email. We sent instructions to reset your password.'
-      } else {
-        return "To reset your password, click Initiate Password Reset. We'll send instructions via email."
       }
-    } else {
-      if (this.state.alreadyInitiated) {
-        return 'Tell the user to check their email. We sent instructions to reset their password.'
-      } else {
-        return "To reset this user's password, click Initiate Password Reset. We'll send them instructions via email."
-      }
+      return "To reset your password, click Initiate Password Reset. We'll send instructions via email."
     }
+
+    // else
+    if (this.state.alreadyInitiated) {
+      return 'Tell the user to check their email. We sent instructions to reset their password.'
+    }
+    return "To reset this user's password, click Initiate Password Reset. We'll send them instructions via email."
   }
 
   render = () => {
-    return this.props.currentUser.loading ? null : (<div>
+    return this.props.currentUser.loading ? null : (<span>
       <RaisedButton
         onTouchTap={this.openDialog}
         label='Reset password'
         variant='outlined'
+        disabled={this.props.disabled}
       />
       <Dialog
         className={css(styles.container)}
@@ -94,7 +98,7 @@ class InitiatePasswordResetDialog extends React.Component {
       >
         {this.text()}
       </Dialog>
-    </div>)
+    </span>)
   }
 }
 
@@ -102,7 +106,8 @@ InitiatePasswordResetDialog.propTypes = {
   currentUser: PropTypes.object,
   organizationId: PropTypes.string,
   userId: PropTypes.string,
-  mutations: PropTypes.object
+  mutations: PropTypes.object,
+  disabled: PropTypes.boolean
 }
 
 const mapMutationsToProps = ({ ownProps }) => ({

--- a/src/containers/InitiatePasswordResetDialog.jsx
+++ b/src/containers/InitiatePasswordResetDialog.jsx
@@ -1,0 +1,123 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import gql from 'graphql-tag'
+import loadData from './hoc/load-data'
+import wrapMutations from './hoc/wrap-mutations'
+import Dialog from 'material-ui/Dialog'
+import RaisedButton from 'material-ui/RaisedButton'
+import { StyleSheet, css } from 'aphrodite'
+
+const styles = StyleSheet.create({
+  button: {
+    marginLeft: '30px'
+  },
+  container: {
+    display: 'flex',
+    flexDirection: 'column'
+  }
+})
+
+class InitiatePasswordResetDialog extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      alreadyInitiated: false,
+      open: false
+    }
+  }
+
+  actions = () => [
+    !this.state.alreadyInitiated && <RaisedButton
+      className={css(styles.button)}
+      label='Initate Password Reset'
+      onTouchTap={async () => this.initiatePasswordReset()}
+      primary
+    />,
+    <RaisedButton
+      className={css(styles.button)}
+      label='Close'
+      onTouchTap={async () => this.closeDialog()}
+      secondary
+    />
+  ]
+
+  initiatePasswordReset = async () => {
+    await this.props.mutations.initiatePasswordReset()
+    this.setState({ alreadyInitiated: true })
+  }
+
+  editingSelf = () => {
+    return this.props.currentUser.id === this.userId
+  }
+
+  openDialog = () => {
+    this.setState({ open: true })
+  }
+
+  closeDialog = () => {
+    this.setState({
+      open: false,
+      alreadyInitiated: false
+    })
+  }
+
+  text = () => {
+    if (this.editingSelf()) {
+      if (this.state.alreadyInitiated) {
+        return 'Check your email. We sent instructions to reset your password.'
+      } else {
+        return "To reset your password, click Initiate Password Reset. We'll send instructions via email."
+      }
+    } else {
+      if (this.state.alreadyInitiated) {
+        return 'Tell the user to check their email. We sent instructions to reset their password.'
+      } else {
+        return "To reset this user's password, click Initiate Password Reset. We'll send them instructions via email."
+      }
+    }
+  }
+
+  render = () => {
+    return this.props.currentUser.loading ? null : (<div>
+      <RaisedButton
+        onTouchTap={this.openDialog}
+        label='Reset password'
+        variant='outlined'
+      />
+      <Dialog
+        className={css(styles.container)}
+        open={this.state.open}
+        actions={this.actions()}
+        modal
+        title='Initiate Password Reset'
+      >
+        {this.text()}
+      </Dialog>
+    </div>)
+  }
+}
+
+InitiatePasswordResetDialog.propTypes = {
+  currentUser: PropTypes.object,
+  organizationId: PropTypes.string,
+  userId: PropTypes.string,
+  mutations: PropTypes.object
+}
+
+const mapMutationsToProps = ({ ownProps }) => ({
+  initiatePasswordReset: () => ({
+    mutation: gql`mutation initiatePasswordReset($organizationId: String!, $userId: String!) {
+      initiatePasswordReset(organizationId: $organizationId, userId: $userId)
+    }`,
+    variables: {
+      userId: ownProps.userId,
+      organizationId: ownProps.organizationId
+    }
+  })
+})
+
+export default loadData(wrapMutations(InitiatePasswordResetDialog), {
+  mapMutationsToProps
+})
+

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -12,6 +12,7 @@ import RaisedButton from 'material-ui/RaisedButton'
 import { StyleSheet, css } from 'aphrodite'
 
 import { dataTest } from '../lib/attributes'
+import InitiatePasswordResetDialog from './InitiatePasswordResetDialog';
 
 const styles = StyleSheet.create({
   buttons: {
@@ -169,11 +170,19 @@ class UserEdit extends React.Component {
           <div className={css(styles.buttons)}>
             {authType !== 'change' && userId && (userId === data.currentUser.id) &&
               <div className={css(styles.container)}>
-                <RaisedButton
-                  onTouchTap={this.handleClick}
-                  label='Change password'
-                  variant='outlined'
-                />
+                {window.PASSPORT_STRATEGY === 'local' ? (
+                  <RaisedButton
+                    onTouchTap={() => this.handleClick()}
+                    label='Change password'
+                    variant='outlined'
+                  />
+                ) : (
+                  <InitiatePasswordResetDialog
+                    currentUser={this.props.editUser}
+                    userId={this.props.userId}
+                    organizationId={this.props.organizationId}
+                  />
+                )}
               </div>}
             <Form.Button
               type='submit'

--- a/src/server/local-auth-helpers.js
+++ b/src/server/local-auth-helpers.js
@@ -148,8 +148,8 @@ export const change = ({
 }) => {
   const pwFieldSplit = user.auth0_id.split('|')
   const hashedPassword = {
-    salt: pwFieldSplit[1],
-    hash: pwFieldSplit[2]
+    salt: pwFieldSplit[0],
+    hash: pwFieldSplit[1]
   }
 
   // Verify password and password confirm fields match


### PR DESCRIPTION
This PR is the fix for the **salt not found** problem that was reported by a texting volunteer on June 19.

The change password (for the user edit) and reset password (for the people page) buttons only work if Spoke is configured to use the local passport strategy.

This PR checks the passport strategy, and if Spoke is not using the local strategy, calls the Auth0 API to initiate a password reset, meaning, an email will be sent to the email address on file for the user whose password is being reset.