### PR TITLE
People page: case insensitive sort and update after editing a user

### DIFF
--- a/src/components/PeopleList/index.jsx
+++ b/src/components/PeopleList/index.jsx
@@ -106,8 +106,10 @@ export class PeopleList extends Component {
 
   updateUser() {
     this.setState({
-      userEdit: false,
-      forceUpdateTime: Date.now()
+      userEdit: false
+    })
+    this.props.users.refetch({
+      cursor: this.state.cursor
     })
   }
 
@@ -147,6 +149,12 @@ export class PeopleList extends Component {
           returnValue.people.pageInfo = fetchMoreResult.data.people.pageInfo
         }
         return returnValue
+      }
+    })
+    this.setState({
+      cursor: {
+        offset: newPage * pageSize,
+        limit: pageSize
       }
     })
   }

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -8,6 +8,8 @@ const created = '"user"."created_at"'
 const oldest = created
 const newest = '"user"."created_at" desc'
 
+const lower = (column) => `lower(${column})`
+
 function buildSelect(sortBy) {
   const userStar = '"user".*'
 
@@ -17,7 +19,7 @@ function buildSelect(sortBy) {
     case 'COUNT_ONLY':
       return r.knex.countDistinct('user.id')
     case 'LAST_NAME':
-      fragmentArray = [userStar]
+      fragmentArray = [userStar, lower(lastName), lower(firstName)]
       break
     case 'NEWEST':
       fragmentArray = [userStar]
@@ -27,7 +29,7 @@ function buildSelect(sortBy) {
       break
     case 'FIRST_NAME':
     default:
-      fragmentArray = [userStar]
+      fragmentArray = [userStar, lower(lastName), lower(firstName)]
       break
   }
 
@@ -41,7 +43,7 @@ function buildOrderBy(query, sortBy) {
     case 'COUNT_ONLY':
       return query
     case 'LAST_NAME':
-      fragmentArray = [lastName, firstName, newest]
+      fragmentArray = [lower(lastName), lower(firstName), newest]
       break
     case 'NEWEST':
       fragmentArray = [newest]
@@ -51,7 +53,7 @@ function buildOrderBy(query, sortBy) {
       break
     case 'FIRST_NAME':
     default:
-      fragmentArray = [firstName, lastName, newest]
+      fragmentArray = [lower(firstName), lower(lastName), newest]
       break
   }
 


### PR DESCRIPTION
- correct case insensitive sort
- refresh after editing a user

This PR addresses people page problems mentioned [here](https://github.com/MoveOnOrg/Spoke/issues/974). 