### PR TITLE
hack to fix unwanted popups in interactions form ON SAFARI ONLY

### DIFF
--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -86,9 +86,8 @@ export default class GSScriptField extends GSFormField {
       <div>
         <TextField
           multiLine
-          onFocus={this.handleOpenDialog}
           onTouchTap={(event) => {
-            event.stopPropagation()
+            this.handleOpenDialog(event)
           }}
           floatingLabelText={this.floatingLabelText()}
           floatingLabelStyle={{


### PR DESCRIPTION
This is described by users as "I need to step through every interaction step before I can do anything."

Upon investigation we realized it only happens on Safari.  That's why I never saw it.

It seems that Safari is causing `onFocus` to fire for the script in every interaction step after the first render.  It's not clear to me why that was happening.  

We were handling `onFocus` to cause the dialog to open and present the script editor, rather than handling it on the click.  That seems unnecessary, because is anybody really going to tab from script to script and expect the dialog to open?  Once it opens, they can't tab to the next step anyway.

So I changed it to cause the script editor to open only when the field is tapped.  That's a hack that works around the root cause, but as I hoped I explained above, this solves the problem and hopefully won't break anyone else's workflow.