### PR TITLE
Optimize tags handling in AssignmentTexterContact

### DIFF
--- a/src/components/ContactToolbar/Tags.jsx
+++ b/src/components/ContactToolbar/Tags.jsx
@@ -1,21 +1,13 @@
 import PropTypes from 'prop-types'
-import gql from 'graphql-tag'
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
-import loadData from '../../containers/hoc/load-data'
 
 import FlagIcon from 'material-ui/svg-icons/content/flag'
-import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
-import { List, ListItem } from 'material-ui/List'
-import moment from 'moment'
-import Theme from '../../styles/theme'
+
+import TagsDialog from './TagsDialog'
 
 const styles = StyleSheet.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column'
-  },
   conversationLink: {
     paddingTop: '25px'
   },
@@ -42,18 +34,12 @@ class Tags extends React.Component {
     }
   }
 
-  dialogActions = <FlatButton
-    label='Close'
-    primary
-    onClick={() => this.handleCloseDialog()}
-  />
-
-  handleCloseDialog = () => {
-    this.setState({ open: false })
-  }
-
   handleOpenDialog = () => {
     this.setState({ open: true })
+  }
+
+  dialogCloseRequested = () => {
+    this.setState({ open: false })
   }
 
   renderButton = () => (
@@ -69,31 +55,11 @@ class Tags extends React.Component {
   )
 
   renderDialog = () => (
-    <Dialog
-      title='Tags'
+    <TagsDialog
       open={this.state.open}
-      actions={this.dialogActions}
-      modal
-    >
-      <div
-        className={css(styles.container)}
-      >
-        <List>
-          {this.props.conversations.conversations.conversations[0].contact.tags.map((tag, index) =>
-            (<ListItem
-              key={index}
-            >
-              <span style={Theme.text.body}>
-                {`${tag.tag} `}
-              </span>
-              <span style={Object.assign({}, Theme.text.body, { fontSize: Theme.text.body.fontSize * 0.8, fontStyle: 'italic' })}>
-                {`${moment(tag.createdAt).format('lll')}`}
-              </span>
-            </ListItem>)
-          )}
-        </List>
-      </div>
-    </Dialog>
+      closeRequested={this.dialogCloseRequested}
+      {...this.props}
+    />
   )
 
   render = () => (
@@ -105,57 +71,9 @@ class Tags extends React.Component {
 }
 
 Tags.propTypes = {
-  open: PropTypes.bool,
   campaign: PropTypes.object,
   campaignContact: PropTypes.object,
-  assignment: PropTypes.object,
-  conversations: PropTypes.object
+  assignment: PropTypes.object
 }
 
-
-const mapQueriesToProps = ({ ownProps }) => ({
-  conversations: {
-    query: gql`
-      query Q(
-        $organizationId: String!
-        $cursor: OffsetLimitCursor!
-        $contactsFilter: ContactsFilter
-      ) {
-        conversations(
-          cursor: $cursor
-          organizationId: $organizationId
-          contactsFilter: $contactsFilter
-        ) {
-          pageInfo {
-            limit
-            offset
-            total
-          }
-          conversations {
-            contact {
-              tags {
-                tag
-                createdAt
-                createdBy {
-                  displayName
-                }
-                resolvedAt
-                resolvedBy {
-                  displayName
-                }
-              }
-            }
-          }
-        }
-      }
-    `,
-    variables: {
-      organizationId: ownProps.campaign.organization.id,
-      cursor: { offset: 0, limit: 1 },
-      contactsFilter: { contactId: ownProps.campaignContact.id }
-    },
-    forceFetch: true
-  }
-})
-
-export default loadData(Tags, { mapQueriesToProps })
+export default Tags

--- a/src/components/ContactToolbar/TagsDialog.jsx
+++ b/src/components/ContactToolbar/TagsDialog.jsx
@@ -1,0 +1,117 @@
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import React from 'react'
+import { StyleSheet, css } from 'aphrodite'
+import loadData from '../../containers/hoc/load-data'
+
+import Dialog from 'material-ui/Dialog'
+import FlatButton from 'material-ui/FlatButton'
+import { List, ListItem } from 'material-ui/List'
+import moment from 'moment'
+import Theme from '../../styles/theme'
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column'
+  }
+})
+
+class TagsDialog extends React.Component {
+
+  dialogActions = <FlatButton
+    label='Close'
+    primary
+    onClick={this.props.closeRequested}
+  />
+
+  render = () => {
+    return this.props.open && (
+      <Dialog
+        title='Tags'
+        open
+        actions={this.dialogActions}
+        modal
+      >
+        <div
+          className={css(styles.container)}
+        >
+          <List>
+            {this.props.conversations.conversations.conversations[0].contact.tags.map((tag, index) =>
+              (<ListItem
+                key={index}
+              >
+                <span style={Theme.text.body}>
+                  {`${tag.tag} `}
+                </span>
+                <span style={Object.assign({}, Theme.text.body, { fontSize: Theme.text.body.fontSize * 0.8, fontStyle: 'italic' })}>
+                  {`${moment(tag.createdAt).format('lll')}`}
+                </span>
+              </ListItem>)
+            )}
+          </List>
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+TagsDialog.propTypes = {
+  open: PropTypes.bool,
+  closeRequested: PropTypes.func,
+  campaign: PropTypes.object,
+  campaignContact: PropTypes.object,
+  assignment: PropTypes.object,
+  conversations: PropTypes.object
+}
+
+
+const mapQueriesToProps = ({ ownProps }) => ({
+  conversations: {
+    query: gql`
+      query Q(
+        $organizationId: String!
+        $cursor: OffsetLimitCursor!
+        $contactsFilter: ContactsFilter
+        $assignmentsFilter: AssignmentsFilter
+      ) {
+        conversations(
+          cursor: $cursor
+          organizationId: $organizationId
+          contactsFilter: $contactsFilter
+          assignmentsFilter: $assignmentsFilter
+        ) {
+          pageInfo {
+            limit
+            offset
+            total
+          }
+          conversations {
+            contact {
+              tags {
+                tag
+                createdAt
+                createdBy {
+                  displayName
+                }
+                resolvedAt
+                resolvedBy {
+                  displayName
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      organizationId: ownProps.campaign.organization.id,
+      cursor: { offset: 0, limit: 1 },
+      contactsFilter: { contactId: ownProps.campaignContact.id },
+      assignmentsFilter: { texterId: ownProps.assignment.texter.id }
+    },
+    forceFetch: true
+  }
+})
+
+export default loadData(TagsDialog, { mapQueriesToProps })

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -60,7 +60,7 @@ import { change } from '../local-auth-helpers'
 import { getSendBeforeTimeUtc } from '../../lib/timezones'
 
 import request from 'request'
-import { flatten } from 'lodash'
+import { flatten, get } from 'lodash'
 import { DateTime } from 'timezonecomplete';
 
 const uuidv4 = require('uuid').v4
@@ -1378,7 +1378,10 @@ const rootResolvers = {
       info
     ) => {
       const { user } = context
-      await accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
+
+      if (!assignmentsFilter || get(assignmentsFilter, 'texterId') !== user.id) {
+        await accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
+      }
 
       return getConversations(
         cursor,


### PR DESCRIPTION
- Only hit the server to get tags if the tags dialog is open.  Otherwise use "pending tags" in CampaignContact to change display of tags button.  Before we were hitting the server each time contact changed.
- Don't require SUPREVOLUNTEER if getting conversations assigned to the current user.