### PR TITLE
suspended texter cutoff 

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -185,6 +185,7 @@ const rootSchema = gql`
 
   type RootQuery {
     currentUser: User
+    currentUserWithAccess(organizationId: String!, role: String!): User
     organization(id:String!, utc:String): Organization
     campaign(id:String!): Campaign
     inviteByHash(hash:String!): [Invite]

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -12,6 +12,7 @@ import Check from 'material-ui/svg-icons/action/check-circle'
 import Lock from 'material-ui/svg-icons/action/lock-outline'
 import Empty from '../components/Empty'
 import RaisedButton from 'material-ui/RaisedButton'
+import { get } from 'lodash'
 
 const styles = StyleSheet.create({
   container: {
@@ -153,7 +154,7 @@ export class AssignmentTexter extends React.Component {
         .filter((cId) => !force || !this.state.contactCache[cId])
       console.log('getContactData batch forward ', getIds)
     } else if (!getIds.length
-               && this.props.assignment.campaign.useDynamicAssignment
+               && get(this.props, 'assignment.campaign.useDynamicAssignment')
                // If we have just crossed the threshold of contact data we have, get more
                && contacts[newIndex + BATCH_FORWARD - 1]
                && !contacts[newIndex + BATCH_FORWARD]) {
@@ -163,8 +164,14 @@ export class AssignmentTexter extends React.Component {
       console.log('getContactData length', newIndex, getIds.length)
       this.setState({ loading: true })
       const contactData = await this.props.loadContacts(getIds)
-      if (this.props.reviewMode && contactData.errors) {
-        this.setState({ contactDataErrors: contactData.errors })
+      if (contactData.errors) {
+        if (this.props.reviewMode) {
+          this.setState({ contactDataErrors: contactData.errors })
+        } else if (this.props.organizationId) {
+          // TODO(lmp) push_suspended
+          console.log(`PUSHING AssignmentTexter 172`)
+          this.props.router.push(`/app/${ this.props.organizationId  }/suspended`)
+        }
       }
 
       const { data: { getAssignmentContacts } } = contactData
@@ -344,7 +351,7 @@ export class AssignmentTexter extends React.Component {
       if (this.props.reviewMode && this.state.contactDataErrors) {
         console.log('REVIEW MODE + CONTACT DATA ERRORS ' + this.state.contactDataErrors)
         return this.renderNotAuthorized()
-      }
+        } 
       const self = this
       console.log('NO CONTACT DATA <curInd><ctct><reloadDelay><curcontacts>', self.state.currentContactIndex,
                   contact, self.state.reloadDelay, this.props.contacts)

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -168,8 +168,6 @@ export class AssignmentTexter extends React.Component {
         if (this.props.reviewMode) {
           this.setState({ contactDataErrors: contactData.errors })
         } else if (this.props.organizationId) {
-          // TODO(lmp) push_suspended
-          console.log(`PUSHING AssignmentTexter 172`)
           this.props.router.push(`/app/${ this.props.organizationId  }/suspended`)
         }
       }

--- a/src/components/ContactToolbar/Tags.jsx
+++ b/src/components/ContactToolbar/Tags.jsx
@@ -1,21 +1,13 @@
 import PropTypes from 'prop-types'
-import gql from 'graphql-tag'
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
-import loadData from '../../containers/hoc/load-data'
 
 import FlagIcon from 'material-ui/svg-icons/content/flag'
-import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
-import { List, ListItem } from 'material-ui/List'
-import moment from 'moment'
-import Theme from '../../styles/theme'
+
+import TagsDialog from './TagsDialog'
 
 const styles = StyleSheet.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column'
-  },
   conversationLink: {
     paddingTop: '25px'
   },
@@ -42,18 +34,12 @@ class Tags extends React.Component {
     }
   }
 
-  dialogActions = <FlatButton
-    label='Close'
-    primary
-    onClick={() => this.handleCloseDialog()}
-  />
-
-  handleCloseDialog = () => {
-    this.setState({ open: false })
-  }
-
   handleOpenDialog = () => {
     this.setState({ open: true })
+  }
+
+  dialogCloseRequested = () => {
+    this.setState({ open: false })
   }
 
   renderButton = () => (
@@ -69,31 +55,11 @@ class Tags extends React.Component {
   )
 
   renderDialog = () => (
-    <Dialog
-      title='Tags'
+    <TagsDialog
       open={this.state.open}
-      actions={this.dialogActions}
-      modal
-    >
-      <div
-        className={css(styles.container)}
-      >
-        <List>
-          {this.props.conversations.conversations.conversations[0].contact.tags.map((tag, index) =>
-            (<ListItem
-              key={index}
-            >
-              <span style={Theme.text.body}>
-                {`${tag.tag} `}
-              </span>
-              <span style={Object.assign({}, Theme.text.body, { fontSize: Theme.text.body.fontSize * 0.8, fontStyle: 'italic' })}>
-                {`${moment(tag.createdAt).format('lll')}`}
-              </span>
-            </ListItem>)
-          )}
-        </List>
-      </div>
-    </Dialog>
+      closeRequested={this.dialogCloseRequested}
+      {...this.props}
+    />
   )
 
   render = () => (
@@ -105,57 +71,9 @@ class Tags extends React.Component {
 }
 
 Tags.propTypes = {
-  open: PropTypes.bool,
   campaign: PropTypes.object,
   campaignContact: PropTypes.object,
-  assignment: PropTypes.object,
-  conversations: PropTypes.object
+  assignment: PropTypes.object
 }
 
-
-const mapQueriesToProps = ({ ownProps }) => ({
-  conversations: {
-    query: gql`
-      query Q(
-        $organizationId: String!
-        $cursor: OffsetLimitCursor!
-        $contactsFilter: ContactsFilter
-      ) {
-        conversations(
-          cursor: $cursor
-          organizationId: $organizationId
-          contactsFilter: $contactsFilter
-        ) {
-          pageInfo {
-            limit
-            offset
-            total
-          }
-          conversations {
-            contact {
-              tags {
-                tag
-                createdAt
-                createdBy {
-                  displayName
-                }
-                resolvedAt
-                resolvedBy {
-                  displayName
-                }
-              }
-            }
-          }
-        }
-      }
-    `,
-    variables: {
-      organizationId: ownProps.campaign.organization.id,
-      cursor: { offset: 0, limit: 1 },
-      contactsFilter: { contactId: ownProps.campaignContact.id }
-    },
-    forceFetch: true
-  }
-})
-
-export default loadData(Tags, { mapQueriesToProps })
+export default Tags

--- a/src/components/ContactToolbar/TagsDialog.jsx
+++ b/src/components/ContactToolbar/TagsDialog.jsx
@@ -1,0 +1,117 @@
+import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
+import React from 'react'
+import { StyleSheet, css } from 'aphrodite'
+import loadData from '../../containers/hoc/load-data'
+
+import Dialog from 'material-ui/Dialog'
+import FlatButton from 'material-ui/FlatButton'
+import { List, ListItem } from 'material-ui/List'
+import moment from 'moment'
+import Theme from '../../styles/theme'
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column'
+  }
+})
+
+class TagsDialog extends React.Component {
+
+  dialogActions = <FlatButton
+    label='Close'
+    primary
+    onClick={this.props.closeRequested}
+  />
+
+  render = () => {
+    return this.props.open && (
+      <Dialog
+        title='Tags'
+        open
+        actions={this.dialogActions}
+        modal
+      >
+        <div
+          className={css(styles.container)}
+        >
+          <List>
+            {this.props.conversations.conversations.conversations[0].contact.tags.map((tag, index) =>
+              (<ListItem
+                key={index}
+              >
+                <span style={Theme.text.body}>
+                  {`${tag.tag} `}
+                </span>
+                <span style={Object.assign({}, Theme.text.body, { fontSize: Theme.text.body.fontSize * 0.8, fontStyle: 'italic' })}>
+                  {`${moment(tag.createdAt).format('lll')}`}
+                </span>
+              </ListItem>)
+            )}
+          </List>
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+TagsDialog.propTypes = {
+  open: PropTypes.bool,
+  closeRequested: PropTypes.func,
+  campaign: PropTypes.object,
+  campaignContact: PropTypes.object,
+  assignment: PropTypes.object,
+  conversations: PropTypes.object
+}
+
+
+const mapQueriesToProps = ({ ownProps }) => ({
+  conversations: {
+    query: gql`
+      query Q(
+        $organizationId: String!
+        $cursor: OffsetLimitCursor!
+        $contactsFilter: ContactsFilter
+        $assignmentsFilter: AssignmentsFilter
+      ) {
+        conversations(
+          cursor: $cursor
+          organizationId: $organizationId
+          contactsFilter: $contactsFilter
+          assignmentsFilter: $assignmentsFilter
+        ) {
+          pageInfo {
+            limit
+            offset
+            total
+          }
+          conversations {
+            contact {
+              tags {
+                tag
+                createdAt
+                createdBy {
+                  displayName
+                }
+                resolvedAt
+                resolvedBy {
+                  displayName
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      organizationId: ownProps.campaign.organization.id,
+      cursor: { offset: 0, limit: 1 },
+      contactsFilter: { contactId: ownProps.campaignContact.id },
+      assignmentsFilter: { texterId: ownProps.assignment.texter.id }
+    },
+    forceFetch: true
+  }
+})
+
+export default loadData(TagsDialog, { mapQueriesToProps })

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -384,7 +384,6 @@ export class AssignmentTexterContact extends React.Component {
       console.log('sendMessage', contact.id)
       const sendMessageResult = await this.props.mutations.sendMessage(message, contact.id)
       if (sendMessageResult.errors && this.props.campaign.organization.id) {
-        console.log(`PUSHING AssignmentTexterContact index 387`)
         this.props.router.push(`/app/${this.props.campaign.organization.id}/suspended`)
       }
 
@@ -461,7 +460,6 @@ export class AssignmentTexterContact extends React.Component {
       if (optOutMessageText.length) {
         const sendMessageResult = await this.props.mutations.sendMessage(message, contact.id)
         if (sendMessageResult.errors && this.props.campaign.organization.id) {
-          console.log(`PUSHING AssignmentTexterContact index 387`)
           this.props.router.push(`/app/${this.props.campaign.organization.id}/suspended`)
         }
       }

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -459,7 +459,11 @@ export class AssignmentTexterContact extends React.Component {
     this.setState({ disabled: true })
     try {
       if (optOutMessageText.length) {
-        await this.props.mutations.sendMessage(message, contact.id)
+        const sendMessageResult = await this.props.mutations.sendMessage(message, contact.id)
+        if (sendMessageResult.errors && this.props.campaign.organization.id) {
+          console.log(`PUSHING AssignmentTexterContact index 387`)
+          this.props.router.push(`/app/${this.props.campaign.organization.id}/suspended`)
+        }
       }
 
       const optOut = {

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -382,7 +382,11 @@ export class AssignmentTexterContact extends React.Component {
       }
       this.setState({ disabled: true })
       console.log('sendMessage', contact.id)
-      await this.props.mutations.sendMessage(message, contact.id)
+      const sendMessageResult = await this.props.mutations.sendMessage(message, contact.id)
+      if (sendMessageResult.errors && this.props.campaign.organization.id) {
+        console.log(`PUSHING AssignmentTexterContact index 387`)
+        this.props.router.push(`/app/${this.props.campaign.organization.id}/suspended`)
+      }
 
       await this.handleSubmitSurveys()
       this.props.onFinishContact(contact.id)

--- a/src/containers/SuspendedTexter.jsx
+++ b/src/containers/SuspendedTexter.jsx
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { withRouter } from 'react-router'
+
+import ErrorOutline from 'material-ui/svg-icons/alert/error-outline'
+
+import Empty from '../components/Empty'
+import loadData from './hoc/load-data'
+
+import gql from 'graphql-tag'
+
+const SuspendedTexter = (props) => {
+  if (!props.currentUser.errors) {
+    console.log(props.currentUser)
+    props.router.push(`/app/${props.organizationId}/todos`)
+    return null
+  }
+
+  return (
+    <div>
+      <Empty
+        title='Your account is suspended. Contact the moderator in Slack.'
+        icon={<ErrorOutline />}
+      />
+    </div>
+  )
+}
+
+SuspendedTexter.propTypes = {
+  organizationId: PropTypes.string.isRequired,
+  currentUser: PropTypes.object,
+  router: PropTypes.object
+}
+
+const mapQueriesToProps = ({ ownProps }) => ({
+  currentUser: {
+    query: gql`
+      query Q($organizationId: String!, $role: String!) {
+        currentUserWithAccess(organizationId: $organizationId, role: $role) {
+          id
+        }
+      }
+    `,
+    variables: {
+      organizationId: ownProps.organizationId,
+      role: 'TEXTER'
+    },
+    forceFetch: true
+  }
+})
+
+export default loadData(withRouter(SuspendedTexter), { mapQueriesToProps })

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import AssignmentTexter from '../components/AssignmentTexter'
+import Empty from '../components/Empty'
 import { withRouter } from 'react-router'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -50,10 +51,21 @@ export class TexterTodo extends React.Component {
     const { assignment } = this.props.data
     this.assignContactsIfNeeded()
     if (!assignment || assignment.campaign.isArchived) {
+      console.log(`LEGACY PUSH TexterTodoList 54`)
       this.props.router.push(
         `/app/${this.props.params.organizationId}/todos`
       )
     }
+  }
+
+  shouldComponentUpdate = (nextProps) => {
+    if (nextProps.data.errors && this.props.params.organizationId) {
+      // TODO(lmp) push_suspended
+
+      console.log(`PUSHING TexterTodo 65 /app/${this.props.params.organizationId}/todos`)
+      this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
+    }
+    return true
   }
 
   assignContactsIfNeeded = async (checkServer = false, currentIndex) => {
@@ -104,6 +116,14 @@ export class TexterTodo extends React.Component {
 
   render() {
     const { assignment } = this.props.data
+
+    if (!assignment || this.props.data.errors && this.props.params.organizationId) {
+      // TODO(lmp) push_suspended
+      console.log(`PUSHING TexterTodoList 122`)
+      this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
+
+    }
+
     const contacts = assignment ? assignment.contacts : []
     const allContactsCount = assignment ? assignment.allContactsCount : 0
     return (

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -60,9 +60,6 @@ export class TexterTodo extends React.Component {
 
   shouldComponentUpdate = (nextProps) => {
     if (nextProps.data.errors && this.props.params.organizationId) {
-      // TODO(lmp) push_suspended
-
-      console.log(`PUSHING TexterTodo 65 /app/${this.props.params.organizationId}/todos`)
       this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
     }
     return true
@@ -118,10 +115,7 @@ export class TexterTodo extends React.Component {
     const { assignment } = this.props.data
 
     if (!assignment || this.props.data.errors && this.props.params.organizationId) {
-      // TODO(lmp) push_suspended
-      console.log(`PUSHING TexterTodoList 122`)
       this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
-
     }
 
     const contacts = assignment ? assignment.contacts : []

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -76,6 +76,14 @@ class TexterTodoList extends React.Component {
 
   render() {
     this.termsAgreed()
+
+    if (this.props.data.errors && this.props.params.organizationId) {
+      // TODO(lmp) push_suspended
+      console.log(`PUSHING TexterTodoList 82`)
+      this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
+      return null
+    }
+
     const todos = this.props.data.currentUser.todos
     const renderedTodos = this.renderTodoList(todos)
 

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -78,8 +78,6 @@ class TexterTodoList extends React.Component {
     this.termsAgreed()
 
     if (this.props.data.errors && this.props.params.organizationId) {
-      // TODO(lmp) push_suspended
-      console.log(`PUSHING TexterTodoList 82`)
       this.props.router.push(`/app/${this.props.params.organizationId}/suspended`)
       return null
     }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -13,6 +13,7 @@ import TopNav from './components/TopNav'
 import DashboardLoader from './containers/DashboardLoader'
 import TexterTodoList from './containers/TexterTodoList'
 import TexterTodo from './containers/TexterTodo'
+import SuspendedTexter from './containers/SuspendedTexter'
 import Login from './components/Login'
 import Terms from './containers/Terms'
 import React from 'react'
@@ -61,6 +62,13 @@ export default function makeRoutes(requireAuth = () => { }) {
             main: (p) => <UserEdit userId={p.params.userId} organizationId={p.params.organizationId} />,
             topNav: (p) => <TopNav title='Account' orgId={p.params.organizationId} />
           }} />
+          <Route
+            path='suspended'
+            components={{
+              main: (p) => <SuspendedTexter organizationId={p.params.organizationId} />,
+              topNav: (p) => <TopNav title='Spoke Texting' orgId={p.params.organizationId} />
+            }}
+          />
           <Route path='todos'>
             <IndexRoute
               components={{

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -237,12 +237,12 @@ export const resolvers = {
       return query
     },
     interactionSteps: async (campaign, _, { user }) => {
-      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
       return campaign.interactionSteps
         || cacheableData.campaign.dbInteractionSteps(campaign.id)
     },
     cannedResponses: async (campaign, { userId }, { user }) => {
-      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
       return await cacheableData.cannedResponse.query({
         userId: userId || '',
         campaignId: campaign.id
@@ -265,7 +265,7 @@ export const resolvers = {
       // This is the same as hasUnassignedContacts, but the access control
       // is different because for TEXTERs it's just for dynamic campaigns
       // but hasUnassignedContacts for admins is for the campaigns list
-      await accessRequired(user, campaign.organization_id, 'SUSPENDED', true)
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
       if (!campaign.use_dynamic_assignment || campaign.is_archived) {
         return false
       }

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -48,13 +48,14 @@ export async function assignmentRequired(user, assignmentId, assignment) {
   return true
 }
 
-export async function assignmentOrSupervolunteerRequired(organizationId, user, assignmentId, assignment) {
+export async function assignmentAndNotSuspended(organizationId, user, assignmentId, assignment, allowSupervolunteer = true) {
   try {
+    await accessRequired(user, organizationId, 'TEXTER')
     await assignmentRequired(user, assignmentId, assignment)
   } catch (e) {
     console.log(typeof e)
-    if (e instanceof GraphQLError) {
-      accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
+    if (e instanceof GraphQLError && allowSupervolunteer) {
+      await accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
     } else {
       throw (e)
     }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -60,7 +60,7 @@ import { change } from '../local-auth-helpers'
 import { getSendBeforeTimeUtc } from '../../lib/timezones'
 
 import request from 'request'
-import { flatten } from 'lodash'
+import { flatten, get } from 'lodash'
 import { DateTime } from 'timezonecomplete';
 
 const uuidv4 = require('uuid').v4
@@ -1378,7 +1378,10 @@ const rootResolvers = {
       info
     ) => {
       const { user } = context
-      await accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
+
+      if (!assignmentsFilter || get(assignmentsFilter, 'texterId') !== user.id) {
+        await accessRequired(user, organizationId, 'SUPERVOLUNTEER', true)
+      }
 
       return getConversations(
         cursor,


### PR DESCRIPTION
This PR blocks `SUSPENDED` testers from sending messages.  Users' role can be changed to `SUSPENDED` in the people page.  If a `SUSPENDED` texter tries to send a message, they will be redirected to `/app/<orgId>/suspended`.  If a texter tries to visit `/app/<orgId>/suspended` and they are not suspended, they will be redirected to `/app/<orgId>/todos`.

This will happen if a tester's status is changed to `SUSPENDED` while they sending texts.  It can also happen if their status changes while they have a contact open, and the app tries to get more contacts, or if they are skipping contacts and the app tries to get more contacts.

I think this is ok to start using.  For a future iteration we might want to consider preventing testers from being assigned contacts if they are suspended.